### PR TITLE
Fix proxy retrieval

### DIFF
--- a/plugins/modules/monitor.py
+++ b/plugins/modules/monitor.py
@@ -344,7 +344,7 @@ def run(api, params, result):
 
     # proxy -> proxyId
     if params["proxy"]:
-        proxy = get_proxy_by_host_port(api, params["proxy_id"]["host"], params["proxy_id"]["port"])
+        proxy = get_proxy_by_host_port(api, params["proxy"]["host"], params["proxy"]["port"])
         params["proxyId"] = proxy["id"]
     del params["proxy"]
 


### PR DESCRIPTION
The documentation of this file says:

```
  proxy:
    description:
      - The proxy of the monitor.
      - Only required if no I(proxyId) specified.
    type: dict
    suboptions:
      host:
        description:
          - The host of the proxy.
          - Only required if no I(proxyId) specified.
        type: str
      port:
        description:
          - The port of the proxy.
          - Only required if no I(proxyId) specified.
        type: int
```

However, proxy["host"] and proxy["port"] are never read. Instead, some non-existing variables called proxy_id["host"] and proxy_id["port"] are read, making it impossible to actually set a proxy.

This patch fixes that (confirmed with local testing)